### PR TITLE
Add default garage capacity

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -10,13 +10,14 @@ class ViewController: UIViewController {
         let name: String
         let coordinate: CLLocationCoordinate2D
         var currentCount: Int
+        var capacity: Int = 100
     }
 
     class GarageAnnotation: NSObject, MKAnnotation {
         let garage: Garage
         var coordinate: CLLocationCoordinate2D { garage.coordinate }
         var title: String? { garage.name }
-        var subtitle: String? { "Spaces: \(garage.currentCount)" }
+        var subtitle: String? { "Spaces: \(garage.currentCount)/\(garage.capacity)" }
         var isFull: Bool { garage.currentCount == 0 }
 
         init(garage: Garage) {

--- a/GatorPark-swiftTests/GatorPark_swiftTests.swift
+++ b/GatorPark-swiftTests/GatorPark_swiftTests.swift
@@ -6,12 +6,19 @@
 //
 
 import Testing
+import MapKit
 @testable import GatorPark_swift
 
 struct GatorPark_swiftTests {
 
     @Test func example() async throws {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+    @Test func defaultCapacityIs100() async throws {
+        let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let garage = ViewController.Garage(name: "Test", coordinate: coordinate, currentCount: 0)
+        #expect(garage.capacity == 100)
     }
 
 }


### PR DESCRIPTION
## Summary
- track garage capacity with a new field and show spaces available out of capacity on pins
- cover default capacity behavior with a unit test

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_688fc0750efc832686385e774071997d