### PR TITLE
Always display red circle for garage pins

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -187,7 +187,10 @@ extension ViewController: MKMapViewDelegate {
             view?.annotation = annotation
         }
         if let garageAnnotation = annotation as? GarageAnnotation {
-            view?.backgroundColor = garageAnnotation.isFull ? .systemRed : .systemBlue
+            // Display a red circle regardless of garage availability.
+            // Full garages remain red and non-full garages are also red.
+            // This removes the previous blue state.
+            view?.backgroundColor = .systemRed
         }
         return view
     }


### PR DESCRIPTION
## Summary
- Always show a red circle for garage annotations
- Remove conditional coloring that showed blue for non-full garages

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_688fc1cd4a908326bea3f15584d602d7