### PR TITLE
Color annotations based on garage capacity

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -18,7 +18,10 @@ class ViewController: UIViewController {
         var coordinate: CLLocationCoordinate2D { garage.coordinate }
         var title: String? { garage.name }
         var subtitle: String? { "Spaces: \(garage.currentCount)/\(garage.capacity)" }
-        var isFull: Bool { garage.currentCount == 0 }
+        /// Indicates whether the garage has reached its capacity.
+        /// A garage is considered full when the number of occupied spaces is
+        /// greater than or equal to its total capacity.
+        var isFull: Bool { garage.currentCount >= garage.capacity }
 
         init(garage: Garage) {
             self.garage = garage

--- a/GatorPark-swiftTests/GatorPark_swiftTests.swift
+++ b/GatorPark-swiftTests/GatorPark_swiftTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Testing
+import UIKit
 import MapKit
 @testable import GatorPark_swift
 
@@ -19,6 +20,22 @@ struct GatorPark_swiftTests {
         let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
         let garage = ViewController.Garage(name: "Test", coordinate: coordinate, currentCount: 0)
         #expect(garage.capacity == 100)
+    }
+
+    @Test func annotationColorReflectsGarageCapacity() async throws {
+        let vc = ViewController()
+        let mapView = MKMapView()
+        let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+
+        let fullGarage = ViewController.Garage(name: "Full", coordinate: coordinate, currentCount: 100, capacity: 100)
+        let fullAnnotation = ViewController.GarageAnnotation(garage: fullGarage)
+        let fullView = vc.mapView(mapView, viewFor: fullAnnotation)
+        #expect(fullView?.backgroundColor == .systemRed)
+
+        let openGarage = ViewController.Garage(name: "Open", coordinate: coordinate, currentCount: 50, capacity: 100)
+        let openAnnotation = ViewController.GarageAnnotation(garage: openGarage)
+        let openView = vc.mapView(mapView, viewFor: openAnnotation)
+        #expect(openView?.backgroundColor == .systemBlue)
     }
 
 }


### PR DESCRIPTION
## Summary
- determine whether a garage is full based on capacity
- verify garage pin colors reflect whether a garage is full

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -project GatorPark-swift.xcodeproj -scheme GatorPark-swift -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_688fc2d7952c8326babfca8d89ba7445