### PR TITLE
Reduce default garage capacity

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -10,7 +10,9 @@ class ViewController: UIViewController {
         let name: String
         let coordinate: CLLocationCoordinate2D
         var currentCount: Int
-        var capacity: Int = 100
+        /// The maximum number of vehicles the garage can hold.
+        /// Defaults to a small value for easier testing.
+        var capacity: Int = 2
     }
 
     class GarageAnnotation: NSObject, MKAnnotation {

--- a/GatorPark-swiftTests/GatorPark_swiftTests.swift
+++ b/GatorPark-swiftTests/GatorPark_swiftTests.swift
@@ -16,10 +16,10 @@ struct GatorPark_swiftTests {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 
-    @Test func defaultCapacityIs100() async throws {
+    @Test func defaultCapacityIsTwo() async throws {
         let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
         let garage = ViewController.Garage(name: "Test", coordinate: coordinate, currentCount: 0)
-        #expect(garage.capacity == 100)
+        #expect(garage.capacity == 2)
     }
 
     @Test func annotationColorReflectsGarageCapacity() async throws {
@@ -27,12 +27,12 @@ struct GatorPark_swiftTests {
         let mapView = MKMapView()
         let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
 
-        let fullGarage = ViewController.Garage(name: "Full", coordinate: coordinate, currentCount: 100, capacity: 100)
+        let fullGarage = ViewController.Garage(name: "Full", coordinate: coordinate, currentCount: 2, capacity: 2)
         let fullAnnotation = ViewController.GarageAnnotation(garage: fullGarage)
         let fullView = vc.mapView(mapView, viewFor: fullAnnotation)
         #expect(fullView?.backgroundColor == .systemRed)
 
-        let openGarage = ViewController.Garage(name: "Open", coordinate: coordinate, currentCount: 50, capacity: 100)
+        let openGarage = ViewController.Garage(name: "Open", coordinate: coordinate, currentCount: 1, capacity: 2)
         let openAnnotation = ViewController.GarageAnnotation(garage: openGarage)
         let openView = vc.mapView(mapView, viewFor: openAnnotation)
         #expect(openView?.backgroundColor == .systemBlue)


### PR DESCRIPTION
## Summary
- Decrease default `Garage` capacity to 2 and document the change
- Update unit tests for new capacity and adjusted full/open values

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_688fc44fd9c48326ada04999738fdc88