### PR TITLE
Style search bar like Google Maps

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -96,12 +96,22 @@ class ViewController: UIViewController {
         searchBar.delegate = self
         searchBar.showsCancelButton = true
         searchBar.placeholder = "Search garages or open spots"
+        searchBar.searchBarStyle = .minimal
+        searchBar.backgroundImage = UIImage()
+
+        if #available(iOS 13.0, *) {
+            let textField = searchBar.searchTextField
+            textField.backgroundColor = .systemBackground
+            textField.layer.cornerRadius = 10
+            textField.layer.masksToBounds = true
+        }
+
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(searchBar)
         NSLayoutConstraint.activate([
-            searchBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            searchBar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 8),
+            searchBar.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 8),
+            searchBar.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -8)
         ])
     }
 


### PR DESCRIPTION
## Summary
- restyle the search bar to resemble Google Maps with rounded text field, minimal chrome, and side padding

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test -project GatorPark-swift.xcodeproj -scheme GatorPark-swift -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_688fc89ae0d08326a55b5bc5bc91fef9