### PR TITLE
Automatically show garage callout after search

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -278,6 +278,13 @@ extension ViewController: UISearchBarDelegate {
             let region = MKCoordinateRegion(center: garage.coordinate,
                                             span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
             mapView.setRegion(region, animated: true)
+            if let annotation = mapView.annotations.first(where: {
+                ($0 as? GarageAnnotation)?.garage.name == garage.name
+            }) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                    self?.mapView.selectAnnotation(annotation, animated: true)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Automatically select a garage's map annotation when it is found via the search bar
- Display check-in and check-out buttons immediately after search

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme GatorPark-swift -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: xcodebuild not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fc9c2db0c8326ab47e6de963fc472