### PR TITLE
Fix initial annotation color for garage availability

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -253,10 +253,8 @@ extension ViewController: MKMapViewDelegate {
             view?.annotation = annotation
         }
         if let garageAnnotation = annotation as? GarageAnnotation {
-            // Display a red circle regardless of garage availability.
-            // Full garages remain red and non-full garages are also red.
-            // This removes the previous blue state.
-            view?.backgroundColor = .systemRed
+            // Reflect the garage availability with annotation color.
+            view?.backgroundColor = garageAnnotation.isFull ? .systemRed : .systemBlue
         }
         return view
     }


### PR DESCRIPTION
## Summary
- Show blue circles for open garages and red for full ones when annotations are created

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688fdb130e348326ae2fa9bab70709a0