### PR TITLE
Expand annotation tap targets and support Dynamic Type

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -32,7 +32,6 @@ class ViewController: UIViewController {
         var garage: Garage
         var coordinate: CLLocationCoordinate2D { garage.coordinate }
         var title: String? { garage.name }
-        var subtitle: String? { "Spaces: \(garage.currentCount)/\(garage.capacity)" }
         var isFull: Bool { garage.currentCount >= garage.capacity }
 
         init(garage: Garage) {
@@ -281,23 +280,27 @@ extension ViewController: MKMapViewDelegate {
         if view == nil {
             view = MKAnnotationView(annotation: annotation, reuseIdentifier: id)
             view?.canShowCallout = true
-            view?.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
-            view?.layer.cornerRadius = 10
+            view?.frame = CGRect(x: 0, y: 0, width: 44, height: 44)
+            view?.layer.cornerRadius = 22
 
             let checkIn = UIButton(type: .system)
             checkIn.setTitle("In", for: .normal)
             checkIn.tintColor = .systemGreen
             checkIn.backgroundColor = UIColor.systemGreen.withAlphaComponent(0.2)
-            checkIn.frame = CGRect(x: 0, y: 0, width: 44, height: 30)
+            checkIn.frame = CGRect(x: 0, y: 0, width: 60, height: 44)
             checkIn.layer.cornerRadius = 5
+            checkIn.titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
+            checkIn.titleLabel?.adjustsFontForContentSizeCategory = true
             view?.leftCalloutAccessoryView = checkIn
 
             let checkOut = UIButton(type: .system)
             checkOut.setTitle("Out", for: .normal)
             checkOut.tintColor = .systemOrange
             checkOut.backgroundColor = UIColor.systemOrange.withAlphaComponent(0.2)
-            checkOut.frame = CGRect(x: 0, y: 0, width: 44, height: 30)
+            checkOut.frame = CGRect(x: 0, y: 0, width: 60, height: 44)
             checkOut.layer.cornerRadius = 5
+            checkOut.titleLabel?.font = UIFont.preferredFont(forTextStyle: .headline)
+            checkOut.titleLabel?.adjustsFontForContentSizeCategory = true
             view?.rightCalloutAccessoryView = checkOut
         } else {
             view?.annotation = annotation
@@ -306,6 +309,18 @@ extension ViewController: MKMapViewDelegate {
             // Reflect the garage availability with annotation color.
             let color = garageAnnotation.isFull ? UIColor.systemRed : UIColor.systemBlue
             view?.backgroundColor = color.withAlphaComponent(0.8)
+
+            let detailLabel: UILabel
+            if let existing = view?.detailCalloutAccessoryView as? UILabel {
+                detailLabel = existing
+            } else {
+                detailLabel = UILabel()
+                detailLabel.numberOfLines = 0
+                detailLabel.font = UIFont.preferredFont(forTextStyle: .subheadline)
+                detailLabel.adjustsFontForContentSizeCategory = true
+                view?.detailCalloutAccessoryView = detailLabel
+            }
+            detailLabel.text = "Spaces: \(garageAnnotation.garage.currentCount)/\(garageAnnotation.garage.capacity)"
         }
         return view
     }
@@ -350,6 +365,9 @@ extension ViewController: MKMapViewDelegate {
             let color = garageAnnotation.isFull ? UIColor.systemRed : UIColor.systemBlue
             annView.backgroundColor = color.withAlphaComponent(0.8)
             annView.annotation = garageAnnotation
+            if let label = annView.detailCalloutAccessoryView as? UILabel {
+                label.text = "Spaces: \(garageAnnotation.garage.currentCount)/\(garageAnnotation.garage.capacity)"
+            }
             mapView.selectAnnotation(garageAnnotation, animated: false)
         }
     }


### PR DESCRIPTION
## Summary
- enlarge annotation views and callout buttons for bigger hit areas
- use Dynamic Type fonts in callout controls and detail label

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild test` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_6894d0923b1883269ce7e574eaefcd24