### PR TITLE
Animate map pins only on initial load

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -43,6 +43,7 @@ class ViewController: UIViewController {
     // Data source: exact coordinates for each garage
     var garages: [Garage] = []
     private var allGarages: [Garage] = []
+    private var hasAnimatedInitialPins = false
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -311,6 +312,8 @@ extension ViewController: MKMapViewDelegate {
     }
 
     func mapView(_ mapView: MKMapView, didAdd views: [MKAnnotationView]) {
+        guard !hasAnimatedInitialPins else { return }
+        hasAnimatedInitialPins = true
         for (index, view) in views.enumerated() {
             guard !(view.annotation is MKUserLocation) else { continue }
             let dropOffset = mapView.bounds.size.height


### PR DESCRIPTION
## Summary
- add hasAnimatedInitialPins flag to ensure pin drop animation occurs only once
- skip animation in subsequent mapView didAdd calls

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_6894dcfb7cbc8326ae12d960fa707ede