### PR TITLE
Update garage capacity to 12

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
         let name: String
         let coordinate: CLLocationCoordinate2D
         var currentCount: Int
-        var capacity: Int = 200
+        var capacity: Int = 12
     }
 
     class GarageAnnotation: NSObject, MKAnnotation {

--- a/GatorPark-swiftTests/GatorPark_swiftTests.swift
+++ b/GatorPark-swiftTests/GatorPark_swiftTests.swift
@@ -16,10 +16,10 @@ struct GatorPark_swiftTests {
         // Write your test here and use APIs like `#expect(...)` to check expected conditions.
     }
 
-    @Test func defaultCapacityIsTwoHundred() async throws {
+    @Test func defaultCapacityIsTwelve() async throws {
         let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
         let garage = ViewController.Garage(name: "Test", coordinate: coordinate, currentCount: 0)
-        #expect(garage.capacity == 200)
+        #expect(garage.capacity == 12)
     }
 
     @Test func annotationColorReflectsGarageCapacity() async throws {
@@ -27,12 +27,12 @@ struct GatorPark_swiftTests {
         let mapView = MKMapView()
         let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
 
-        let fullGarage = ViewController.Garage(name: "Full", coordinate: coordinate, currentCount: 200, capacity: 200)
+        let fullGarage = ViewController.Garage(name: "Full", coordinate: coordinate, currentCount: 12, capacity: 12)
         let fullAnnotation = ViewController.GarageAnnotation(garage: fullGarage)
         let fullView = vc.mapView(mapView, viewFor: fullAnnotation)
         #expect(fullView?.backgroundColor == .systemRed)
 
-        let openGarage = ViewController.Garage(name: "Open", coordinate: coordinate, currentCount: 199, capacity: 200)
+        let openGarage = ViewController.Garage(name: "Open", coordinate: coordinate, currentCount: 11, capacity: 12)
         let openAnnotation = ViewController.GarageAnnotation(garage: openGarage)
         let openView = vc.mapView(mapView, viewFor: openAnnotation)
         #expect(openView?.backgroundColor == .systemBlue)


### PR DESCRIPTION
## Summary
- Set default garage capacity to 12
- Adjust tests for new garage capacity and annotation colors

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68963d435bd48326b77938fc93bfd4ae