### PR TITLE
Include garage name in checkout reminder

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -307,11 +307,11 @@ class ViewController: UIViewController {
         mapView.setRegion(r, animated: true)
     }
 
-    private func scheduleCheckoutReminder() {
+    private func scheduleCheckoutReminder(for garage: Garage) {
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [checkoutReminderID])
         let content = UNMutableNotificationContent()
         content.title = "Checkout Reminder"
-        content.body = "Don't forget to check out of your spot."
+        content.body = "Don't forget to check out of \(garage.name)."
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 20, repeats: false)
         let request = UNNotificationRequest(identifier: checkoutReminderID, content: content, trigger: trigger)
         UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
@@ -413,7 +413,7 @@ extension ViewController: MKMapViewDelegate {
                     self.garages[index].currentCount += 1
                     garageAnnotation.garage.currentCount = self.garages[index].currentCount
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    self.scheduleCheckoutReminder()
+                    self.scheduleCheckoutReminder(for: garageAnnotation.garage)
                 }
             } else {
                 if self.garages[index].currentCount > 0 {


### PR DESCRIPTION
## Summary
- notify users which garage they checked into when reminding them to check out

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896477f4e7c83268cd706673504e29f