### PR TITLE
Add basic location tracking with simulated campus start

### DIFF
--- a/GatorPark-swift/Info.plist
+++ b/GatorPark-swift/Info.plist
@@ -20,6 +20,8 @@
 				</dict>
 			</array>
 		</dict>
-	</dict>
+        </dict>
+        <key>NSLocationWhenInUseUsageDescription</key>
+        <string>Your location is used to display your position on the campus map.</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- integrate CoreLocation to track and follow the user's position
- start the map at a simulated campus coordinate so location can be previewed remotely
- add usage description for location permission

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*


------
https://chatgpt.com/codex/tasks/task_e_689649bf310483268907af2188ca78a2