### PR TITLE
Extend checkout reminder notification delay

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -290,7 +290,7 @@ class ViewController: UIViewController {
         let content = UNMutableNotificationContent()
         content.title = "Checkout Reminder"
         content.body = "Don't forget to check out of \(garage.name)."
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 20, repeats: false)
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 2.5 * 60 * 60, repeats: false)
         let request = UNNotificationRequest(identifier: checkoutReminderID, content: content, trigger: trigger)
         UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
     }


### PR DESCRIPTION
## Summary
- extend checkout reminder notification delay from seconds to 2.5 hours

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6896596bdfc083268854da72a0212267