### PR TITLE
Schedule checkout reminder 2.5 hours after check-in

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -291,7 +291,8 @@ class ViewController: UIViewController {
         let content = UNMutableNotificationContent()
         content.title = "Checkout Reminder"
         content.body = "Don't forget to check out of \(garage.name)."
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 20, repeats: false)
+        // Trigger a reminder 2.5 hours (9,000 seconds) after check-in
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 2.5 * 60 * 60, repeats: false)
         let request = UNNotificationRequest(identifier: checkoutReminderID, content: content, trigger: trigger)
         UNUserNotificationCenter.current().add(request, withCompletionHandler: nil)
     }


### PR DESCRIPTION
## Summary
- schedule checkout reminder 2.5 hours after checking into a garage

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689661f27b788326ac2ca8798e000889