### PR TITLE
Fix persistent annotation background after check-in

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -430,10 +430,10 @@ extension ViewController: MKMapViewDelegate {
 
             if let annView = self.mapView.view(for: garageAnnotation) {
                 let color = garageAnnotation.isFull ? UIColor.systemRed : UIColor.systemBlue
-                annView.backgroundColor = color.withAlphaComponent(0.8)
+                annView.markerTintColor = color
                 annView.annotation = garageAnnotation
                 self.mapView.selectAnnotation(garageAnnotation, animated: false)
-
+                
                 if let stack = annView.detailCalloutAccessoryView as? UIStackView,
                    let statusLabel = stack.arrangedSubviews.first as? UILabel,
                    let progress = stack.arrangedSubviews.last as? UIProgressView {


### PR DESCRIPTION
## Summary
- Fix annotation color update to avoid tinting the whole marker background after check in/out

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_689664ff953c832691c5179975bb21df