### PR TITLE
Fix incorrect annotation view type for marker customization

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -428,12 +428,12 @@ extension ViewController: MKMapViewDelegate {
                 }
             }
 
-            if let annView = self.mapView.view(for: garageAnnotation) {
+            if let annView = self.mapView.view(for: garageAnnotation) as? MKMarkerAnnotationView {
                 let color = garageAnnotation.isFull ? UIColor.systemRed : UIColor.systemBlue
                 annView.markerTintColor = color
                 annView.annotation = garageAnnotation
                 self.mapView.selectAnnotation(garageAnnotation, animated: false)
-                
+
                 if let stack = annView.detailCalloutAccessoryView as? UIStackView,
                    let statusLabel = stack.arrangedSubviews.first as? UILabel,
                    let progress = stack.arrangedSubviews.last as? UIProgressView {


### PR DESCRIPTION
## Summary
- Ensure callout update uses `MKMarkerAnnotationView` when changing pin colors

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68966b65bc508326a20a904df240ce37