### PR TITLE
Display garage fullness percentage

### DIFF
--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -41,7 +41,8 @@ class ViewController: UIViewController {
             default:
                 availability = "low availability"
             }
-            return "Spaces: \(occupied)/\(capacity) - \(availability)"
+            let percentage = capacity > 0 ? Int((Float(occupied) / Float(capacity)) * 100) : 0
+            return "Spaces: \(occupied)/\(capacity) (\(percentage)% full) - \(availability)"
         }
         /// Fraction of occupied spaces 0.0...1.0
         var occupancy: Float {
@@ -350,7 +351,8 @@ extension ViewController: MKMapViewDelegate {
             // Display the numeric capacity alongside progress
             let capacityLabel = UILabel()
             capacityLabel.font = UIFont.systemFont(ofSize: 12)
-            capacityLabel.text = "\(garageAnnotation.garage.currentCount)/\(garageAnnotation.garage.capacity) spaces"
+            let percent = Int(garageAnnotation.occupancy * 100)
+            capacityLabel.text = "\(garageAnnotation.garage.currentCount)/\(garageAnnotation.garage.capacity) spaces (\(percent)% full)"
 
             let stack = UIStackView(arrangedSubviews: [statusLabel, progress, capacityLabel])
             stack.axis = .vertical

--- a/GatorPark-swiftTests/GatorPark_swiftTests.swift
+++ b/GatorPark-swiftTests/GatorPark_swiftTests.swift
@@ -38,4 +38,11 @@ struct GatorPark_swiftTests {
         #expect(openView?.backgroundColor == .systemBlue)
     }
 
+    @Test func subtitleIncludesFullnessPercentage() async throws {
+        let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let garage = ViewController.Garage(name: "Half Full", coordinate: coordinate, currentCount: 6, capacity: 12)
+        let annotation = ViewController.GarageAnnotation(garage: garage)
+        #expect(annotation.subtitle == "Spaces: 6/12 (50% full) - moderate availability")
+    }
+
 }


### PR DESCRIPTION
## Summary
- show percentage fullness in garage annotation subtitles and callouts
- add unit test for fullness percentage display

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4534c86c832687e17fdb3cbf77e8