### PR TITLE
Replace HTTP garage service with Firestore

### DIFF
--- a/GatorPark-swift/Garage.swift
+++ b/GatorPark-swift/Garage.swift
@@ -1,14 +1,30 @@
 import Foundation
 import CoreLocation
+import FirebaseFirestore
 
-struct Garage: Codable {
+struct Garage {
+    let id: String
     let name: String
-    let latitude: Double
-    let longitude: Double
+    let coordinate: CLLocationCoordinate2D
+    let capacity: Int
     var currentCount: Int
-    var capacity: Int
+    let isOpen: Bool
 
-    var coordinate: CLLocationCoordinate2D {
-        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    init?(from document: DocumentSnapshot) {
+        guard let data = document.data(),
+              let name = data["name"] as? String,
+              let latitude = data["latitude"] as? CLLocationDegrees,
+              let longitude = data["longitude"] as? CLLocationDegrees,
+              let capacity = data["capacity"] as? Int,
+              let currentCount = data["currentCount"] as? Int,
+              let isOpen = data["isOpen"] as? Bool else {
+            return nil
+        }
+        self.id = document.documentID
+        self.name = name
+        self.coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        self.capacity = capacity
+        self.currentCount = currentCount
+        self.isOpen = isOpen
     }
 }

--- a/GatorPark-swift/GarageService.swift
+++ b/GatorPark-swift/GarageService.swift
@@ -1,70 +1,15 @@
 import Foundation
+import FirebaseFirestore
 
 final class GarageService {
     static let shared = GarageService()
-    private let baseURL = URL(string: "http://localhost:3000")!
-    private var webSocketTask: URLSessionWebSocketTask?
+    private let db = Firestore.firestore()
+    private init() {}
 
-    func fetchGarages(completion: @escaping ([Garage]) -> Void) {
-        let url = baseURL.appendingPathComponent("garages")
-        URLSession.shared.dataTask(with: url) { data, _, _ in
-            if let data = data,
-               let garages = try? JSONDecoder().decode([Garage].self, from: data) {
-                DispatchQueue.main.async {
-                    completion(garages)
-                }
-            } else {
-                DispatchQueue.main.async { completion([]) }
-            }
-        }.resume()
-    }
-
-    func listenForUpdates(onUpdate: @escaping (Garage) -> Void) {
-        let wsURL = URL(string: "ws://localhost:3000")!
-        webSocketTask = URLSession.shared.webSocketTask(with: wsURL)
-        webSocketTask?.resume()
-        receiveUpdate(onUpdate)
-    }
-
-    private func receiveUpdate(_ onUpdate: @escaping (Garage) -> Void) {
-        webSocketTask?.receive { [weak self] result in
-            switch result {
-            case .success(let message):
-                switch message {
-                case .data(let data):
-                    if let garage = try? JSONDecoder().decode(Garage.self, from: data) {
-                        DispatchQueue.main.async { onUpdate(garage) }
-                    }
-                case .string(let string):
-                    if let data = string.data(using: .utf8),
-                       let garage = try? JSONDecoder().decode(Garage.self, from: data) {
-                        DispatchQueue.main.async { onUpdate(garage) }
-                    }
-                @unknown default:
-                    break
-                }
-            case .failure:
-                break
-            }
-            self?.receiveUpdate(onUpdate)
+    func observeGarages(onChange: @escaping ([Garage]) -> Void) {
+        db.collection("garages").addSnapshotListener { snapshot, _ in
+            let garages = snapshot?.documents.compactMap { Garage(from: $0) } ?? []
+            onChange(garages)
         }
-    }
-
-    func checkIn(garageName: String) {
-        updateGarage(garageName: garageName, action: "checkin")
-    }
-
-    func checkOut(garageName: String) {
-        updateGarage(garageName: garageName, action: "checkout")
-    }
-
-    private func updateGarage(garageName: String, action: String) {
-        guard let encoded = garageName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else { return }
-        let url = baseURL.appendingPathComponent("garages/")
-            .appendingPathComponent(encoded)
-            .appendingPathComponent(action)
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        URLSession.shared.dataTask(with: request).resume()
     }
 }

--- a/GatorPark-swift/ViewController.swift
+++ b/GatorPark-swift/ViewController.swift
@@ -72,13 +72,10 @@ class ViewController: UIViewController {
         setupMap()
         setupSearchBar()
         setupSuggestionsTableView()
-        service.fetchGarages { [weak self] garages in
+        service.observeGarages { [weak self] garages in
             self?.garages = garages
             self?.allGarages = garages
             self?.addGaragePins()
-        }
-        service.listenForUpdates { [weak self] garage in
-            self?.updateGarage(garage)
         }
         addZoomButtons()
     }
@@ -198,31 +195,6 @@ class ViewController: UIViewController {
         }
     }
 
-    private func updateGarage(_ updated: Garage) {
-        if let idx = garages.firstIndex(where: { $0.name == updated.name }) {
-            garages[idx] = updated
-        }
-        if let idx = allGarages.firstIndex(where: { $0.name == updated.name }) {
-            allGarages[idx] = updated
-        }
-        if let annotation = mapView.annotations.first(where: { ($0 as? GarageAnnotation)?.garage.name == updated.name }) as? GarageAnnotation {
-            annotation.garage = updated
-            if let annView = mapView.view(for: annotation) as? MKMarkerAnnotationView {
-                let color = annotation.isFull ? UIColor.systemRed : UIColor.systemBlue
-                annView.markerTintColor = color
-                if let stack = annView.detailCalloutAccessoryView as? UIStackView,
-                   let statusLabel = stack.arrangedSubviews.first as? UILabel,
-                   let progress = stack.arrangedSubviews.last as? UIProgressView {
-                    statusLabel.text = annotation.percentageText
-                    progress.progress = annotation.occupancy
-                }
-                annView.annotation = annotation
-            }
-        } else {
-            addGaragePins(fitAll: false)
-        }
-    }
-    
     private func addZoomButtons() {
         let zoomInButton = UIButton(type: .system)
         zoomInButton.setTitle("+", for: .normal)
@@ -406,7 +378,6 @@ extension ViewController: MKMapViewDelegate {
                     self.checkedInGarage = garageAnnotation.garage.name
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     self.scheduleCheckoutReminder(for: garageAnnotation.garage)
-                    self.service.checkIn(garageName: garageAnnotation.garage.name)
                 }
             } else {
                 if self.garages[index].currentCount > 0 {
@@ -415,7 +386,6 @@ extension ViewController: MKMapViewDelegate {
                     self.checkedInGarage = nil
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     self.cancelCheckoutReminder()
-                    self.service.checkOut(garageName: garageAnnotation.garage.name)
                 }
             }
 


### PR DESCRIPTION
## Summary
- switch garage data model to Firestore-backed `Garage` with document-based initializer
- replace HTTP/WebSocket service with Firestore listener
- update view controller to observe Firestore garages and drop check in/out network calls

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab718c96c0832693c06782fb257861