### PR TITLE
Add check-out transaction to GarageService

### DIFF
--- a/GatorPark-swift/GarageService.swift
+++ b/GatorPark-swift/GarageService.swift
@@ -49,4 +49,33 @@ final class GarageService {
             }
         }
     }
+
+    func checkOut(from garage: Garage, completion: @escaping (Result<Void, Error>) -> Void) {
+        let ref = db.collection("garages").document(garage.id)
+
+        db.runTransaction({ (transaction, errorPointer) -> Any? in
+            let document: DocumentSnapshot
+            do {
+                document = try transaction.getDocument(ref)
+            } catch let error as NSError {
+                errorPointer?.pointee = error
+                return nil
+            }
+
+            guard let data = document.data(),
+                  let currentCount = data["currentCount"] as? Int else {
+                return nil
+            }
+
+            let newCount = max(currentCount - 1, 0)
+            transaction.updateData(["currentCount": newCount], forDocument: ref)
+            return nil
+        }) { (_, error) in
+            if let error = error {
+                completion(.failure(error))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Add `checkOut(from:)` to `GarageService` to decrement `currentCount` via Firestore transaction and prevent negatives.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab739c82a48326a994ebf570f5f32b