### PR TITLE
Align Firestore field names with updated schema

### DIFF
--- a/GatorPark-swift/Garage.swift
+++ b/GatorPark-swift/Garage.swift
@@ -12,17 +12,16 @@ struct Garage {
 
     init?(from document: DocumentSnapshot) {
         guard let data = document.data(),
-              let name = data["name"] as? String,
-              let latitude = data["latitude"] as? CLLocationDegrees,
-              let longitude = data["longitude"] as? CLLocationDegrees,
-              let capacity = data["capacity"] as? Int,
-              let currentCount = data["currentCount"] as? Int,
-              let isOpen = data["isOpen"] as? Bool else {
+              let name = data["Name"] as? String,
+              let location = data["Location"] as? GeoPoint,
+              let capacity = data["Capacity"] as? Int,
+              let currentCount = data["Currentcount"] as? Int,
+              let isOpen = data["Isopen"] as? Bool else {
             return nil
         }
         self.id = document.documentID
         self.name = name
-        self.coordinate = CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+        self.coordinate = CLLocationCoordinate2D(latitude: location.latitude, longitude: location.longitude)
         self.capacity = capacity
         self.currentCount = currentCount
         self.isOpen = isOpen

--- a/GatorPark-swift/GarageService.swift
+++ b/GatorPark-swift/GarageService.swift
@@ -26,13 +26,13 @@ final class GarageService {
             }
 
             guard let data = document.data(),
-                  let capacity = data["capacity"] as? Int,
-                  let currentCount = data["currentCount"] as? Int else {
+                  let capacity = data["Capacity"] as? Int,
+                  let currentCount = data["Currentcount"] as? Int else {
                 return nil
             }
 
             if currentCount < capacity {
-                transaction.updateData(["currentCount": currentCount + 1], forDocument: ref)
+                transaction.updateData(["Currentcount": currentCount + 1], forDocument: ref)
             } else {
                 errorPointer?.pointee = NSError(
                     domain: "GarageService",
@@ -63,12 +63,12 @@ final class GarageService {
             }
 
             guard let data = document.data(),
-                  let currentCount = data["currentCount"] as? Int else {
+                  let currentCount = data["Currentcount"] as? Int else {
                 return nil
             }
 
             let newCount = max(currentCount - 1, 0)
-            transaction.updateData(["currentCount": newCount], forDocument: ref)
+            transaction.updateData(["Currentcount": newCount], forDocument: ref)
             return nil
         }) { (_, error) in
             if let error = error {


### PR DESCRIPTION
## Summary
- Parse Garage documents using capitalized Firestore fields (`Name`, `Capacity`, `Currentcount`, `Isopen`, `Location`)
- Update check-in/out transactions to read and write `Currentcount` and `Capacity`

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ab81e301b4832687e7ab2b2770d701