### PR TITLE
Add Firebase App Check debug provider

### DIFF
--- a/GatorPark-swift/AppDelegate.swift
+++ b/GatorPark-swift/AppDelegate.swift
@@ -9,12 +9,24 @@ import UIKit
 import UserNotifications
 import FirebaseCore
 import FirebaseAuth
+import FirebaseAppCheck
+
+#if DEBUG
+class DebugAppCheckProviderFactory: AppCheckProviderFactory {
+    override func createProvider(with app: FirebaseApp) -> AppCheckProvider? {
+        return AppCheckDebugProvider(app: app)
+    }
+}
+#endif
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     private let notificationCenter = UNUserNotificationCenter.current()
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        #if DEBUG
+        AppCheck.setAppCheckProviderFactory(DebugAppCheckProviderFactory())
+        #endif
         FirebaseApp.configure()
 
         if Auth.auth().currentUser == nil {


### PR DESCRIPTION
## Summary
- integrate Firebase App Check Debug provider to allow App Check tokens during development

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68ac33bf34408326849d21b28ffef6b0