### PR TITLE
Fix DebugAppCheckProviderFactory inheritance

### DIFF
--- a/GatorPark-swift/AppDelegate.swift
+++ b/GatorPark-swift/AppDelegate.swift
@@ -12,8 +12,8 @@ import FirebaseAuth
 import FirebaseAppCheck
 
 #if DEBUG
-class DebugAppCheckProviderFactory: AppCheckProviderFactory {
-    override func createProvider(with app: FirebaseApp) -> AppCheckProvider? {
+class DebugAppCheckProviderFactory: NSObject, AppCheckProviderFactory {
+    func createProvider(with app: FirebaseApp) -> AppCheckProvider? {
         return AppCheckDebugProvider(app: app)
     }
 }


### PR DESCRIPTION
## Summary
- fix DebugAppCheckProviderFactory by inheriting from NSObject and conforming to AppCheckProviderFactory protocol

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project GatorPark-swift.xcodeproj -scheme GatorPark-swift -configuration Debug build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3530e54c83269c0e477f7d4ed1f9